### PR TITLE
fix: 수정하기 모달 닫기 시, 입력 폼 초기화

### DIFF
--- a/common/css/modal.css
+++ b/common/css/modal.css
@@ -232,6 +232,7 @@ textarea.form-control {
 }
 
 #current-thumbnail-img {
+  display: none;
   width: 100%;
   object-fit: cover;
   object-position: center;

--- a/common/js/components/CourseModal.js
+++ b/common/js/components/CourseModal.js
@@ -42,7 +42,7 @@ const bindEvents = () => {
 
     const ok = await submitHandler();
 
-    // 모달 HTML 요소 초기화
-    closeModal();
+    // 폼 제출 시 모달 HTML 요소 초기화
+    if (ok) closeModal(modalMode);
   });
 };

--- a/common/js/utils/bindModalEvents.js
+++ b/common/js/utils/bindModalEvents.js
@@ -29,13 +29,13 @@ export function bindModalEvents() {
     // 닫기
     const closeBtn = e.target.closest(".modal-close, .cancel-btn");
     if (closeBtn) {
-      if (modal) closeModal(modal);
+      if (modal) closeModal(modal.dataset.mode);
       return;
     }
 
     // 배경 클릭 시 닫기
     if (e.target.classList.contains("modal")) {
-      closeModal(modal);
+      closeModal(modal.dataset.mode);
     }
   });
 }


### PR DESCRIPTION
## 변경 사항

1. 기존에는 폼 제출 시 closeModal에 모달 mode를 인수로 전달하여 폼 초기화 로직을 수행했었습니다.
2. 하지만, 모달의 배경을 클릭하거나 취소 버튼을 클릭 시 모달 그 자체를 인수로 전달하고 있어 버그가 발생했었습니다.
3. 인수로 모달.dataset.mode를 알맞게 전달하여 버그를 수정하였습니다.
4. 또한, 초기 미리보기 img의 display 속성을 none으로 설정하여 엑박을 방지했습니다.

close #55 
