### PR TITLE
feat: UX 개선 - 반응형 수정

### DIFF
--- a/common/css/header.css
+++ b/common/css/header.css
@@ -364,8 +364,13 @@
   .header-content {
     flex-wrap: wrap;
     gap: 1rem;
+    display: flex;
+    justify-content: space-between;
   }
 
+  .logo {
+    margin-right: 60px;
+  }
   .header-controls {
     width: 100%;
     max-width: none;
@@ -388,6 +393,13 @@
   .header-mega {
     grid-template-columns: repeat(2, minmax(160px, 1fr));
     gap: 1.25rem;
+  }
+  .nav-menu {
+    justify-self: flex-end;
+    order: 2;
+  }
+  .header-controls {
+    order: 3;
   }
 }
 

--- a/lectures/css/courseCard.css
+++ b/lectures/css/courseCard.css
@@ -271,6 +271,9 @@
 }
 
 @media (max-width: 1024px) {
+  .course-card__media {
+    height: 40vh;
+  }
   .course-card__hover-panel {
     position: static;
     width: 100%;
@@ -289,6 +292,10 @@
 }
 
 @media (max-width: 768px) {
+  .course-card__media {
+    height: 60vh;
+  }
+
   .course-card {
     padding: 1rem;
   }

--- a/lectures/css/courseContainer.css
+++ b/lectures/css/courseContainer.css
@@ -188,13 +188,13 @@
   }
 
   .course-grid {
-    grid-template-columns: repeat(3, minmax(220px, 1fr));
+    grid-template-columns: repeat(2, minmax(220px, 1fr));
   }
 }
 
 @media (max-width: 768px) {
   .course-grid {
-    grid-template-columns: repeat(2, minmax(220px, 1fr));
+    grid-template-columns: repeat(1, minmax(220px, 1fr));
     gap: 1.1rem;
   }
 
@@ -204,12 +204,6 @@
 
   .filter-sidebar {
     padding: 1.5rem;
-  }
-
-  .pagination {
-    flex-direction: column;
-    gap: 0.75rem;
-    text-align: center;
   }
 }
 
@@ -227,10 +221,6 @@
   }
 
   .course-section__search {
-    width: 100%;
-  }
-
-  .pagination__control {
     width: 100%;
   }
 }

--- a/lectures/css/pagination.css
+++ b/lectures/css/pagination.css
@@ -61,3 +61,17 @@
   color: #fff;
   box-shadow: 0 18px 30px var(--color-brand-soft-strong);
 }
+
+@media (max-width: 768px) {
+  .pagination {
+    flex-direction: row;
+    gap: 0.75rem;
+    text-align: center;
+  }
+}
+
+@media (max-width: 540px) {
+  .pagination__control {
+    width: 100%;
+  }
+}

--- a/lectures/details/css/lectureDetails.css
+++ b/lectures/details/css/lectureDetails.css
@@ -388,3 +388,40 @@ body {
   box-shadow: 0 10px 18px rgba(var(--color-brand-rgb), 0.2);
   border-color: rgba(var(--color-brand-rgb), 0.4);
 }
+
+@media (max-width: 1330px) {
+  .lecture-detail {
+    /*argin: 0 40px;*/
+  }
+}
+
+@media (max-width: 981px) {
+  .lecture-hero {
+    display: flex;
+    flex-direction: column;
+  }
+  .lecture-hero__content {
+    order: 2;
+    width: 100%;
+  }
+
+  .lecture-hero__media {
+    order: 1;
+  }
+  .lecture-body {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    align-items: normal;
+    padding: 0;
+    margin: 0;
+  }
+  .lecture-body__content {
+    order: 2;
+    display: block;
+  }
+  .lecture-description {
+    order: 1;
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## 변경 사항

- Header
  모바일 환경에서 logo → searchbar → register button 순으로 정렬
  Flex 및 order 속성 적용
  모바일 뷰에서 여백(padding, margin) 재조정
- Course Grid
  모바일: 1열 구조
  태블릿 이상: 2열 구조
  썸네일 이미지 비율 고정 및 높이 조정
- Pagination 
  태블릿 이하 사이즈에서 flex-direction: row로 변경
  정렬 중앙 정렬(justify-content: center)로 수정
- 상세 페이지 (Lecture Details)
- 타이틀, 상세설명, 버튼의 표시 순서 모바일 기준 재배치
  flex-direction 및 order 속성 활용
  모바일 뷰에서 레이아웃 재구성 및 간격 조정


**요약**
- CSS @media (max-width: 981px) 반응형 스타일 추가
- 일부 Grid → Flex 전환
**PC 버전 디자인 영향 없음**

## 리뷰 필요

- [ ] 테스트 Chrome DevTools 모바일 뷰 (iPhone 12Pro, iPhone 14, iPad Air)



## 추후 할 일
- 모바일에서 필터바 버튼 제공 및 클릭 시 필터 메뉴 열림 기능 추가
- 마이페이지  1280px 이하 화면에서 목록 사라짐 현상 개선 + 사이드바 버튼 제공

close #64 
